### PR TITLE
Add filter-btn event listener and refactor filter test - fixes #15 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 // grab add button
 const addBtn = document.querySelector('#add-btn');
+const filterBtn = document.querySelector('#filter-btn');
 const taskList = document.querySelector('#result');
 // initialize delete and edit buttons in global scope
 let editBtn;
 let deleteBtn;
 let deletedTasks = 0;
+let isHidden = false;
 
 // add event listener to button
 addBtn.addEventListener('click', () => {
@@ -61,4 +63,17 @@ addBtn.addEventListener('click', () => {
         deletedTasks++;
         taskCard.setAttribute("hidden", true);
     })
+})
+
+filterBtn.addEventListener('click', () => {
+    const completedTasks = document.querySelectorAll('.completed-task');
+    // if tasks are not hidden - hide them
+    if (!isHidden) {
+        isHidden = true;
+        completedTasks.forEach(task => task.setAttribute('hidden', true)); 
+    } else {
+        // if tasks are hidden - reveal them
+        isHidden = false;
+        completedTasks.forEach(task => task.removeAttribute('hidden')); 
+    }
 })

--- a/index.test.js
+++ b/index.test.js
@@ -71,23 +71,16 @@ test("Clicking the edit button enables editing", () => {
 
 // test for toggling a button to hide completed items
 test("Toggling the filter hides completed tasks from the list", () => {
-    // grab the filter button
-    const filterBtn = document.querySelector('#filter-btn');
-    // prevent page refresh on btn click
-    filterBtn.addEventListener('click', (e) => {
-        e.preventDefault();
-    })
-    // click it
+    // add new task
+    addBtn.click();
+    // grab task card
+    const taskCard = document.querySelector('.task-card');
+    // mark task as completed
+    taskCard.classList.add('completed-task');
+    // click filter button
     filterBtn.click();
     // if the item has a classlist of 'completed-task' it should be hidden
-    // get all list items as array
-    const allItems = Array.from(document.querySelectorAll('input.task'));
-    // check they contain a classlist of 'completed-task' and a hidden attribute of true
-    if (allItems.every(item => item.classList.contains('completed-task') && item.hidden === true)) {
-        console.info("Pass: completed tasks are hidden")
-    } else {
-        console.error("Fail: completed tasks are not hidden")
-    };
-
-    });
-
+    // check task card contain a classlist of 'completed-task' and a hidden attribute of true
+    equal((taskCard.classList.contains('completed-task') && taskCard.hidden), true,'completed tasks are hidden')
+    taskCard.remove();
+});


### PR DESCRIPTION
Hi Milly, 

I added the 'hide completed' button functionality and refactored the correlating test. It will not work on new tasks added to the list just yet. It will work once we have the ability to mark tasks as completed. I based the code on the idea that if a user clicks the checkmark, the task card gets a `class= "completed-task"` added to it and then we check for that class and add a `hidden` attribute to elements that contain that class. If this makes sense then please add the `completed-task` class to the completed task card in your event listener for the checkmark. Let me know if you have any questions, it might be a bit easier to explain over Zoom!  

🌷 

