### PR TITLE
Edit btn

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,10 @@ const filterBtn = document.querySelector('#filter-btn');
 const taskList = document.querySelector('#result');
 // initialize delete and edit buttons in global scope
 let addedTasks = 0;
-let editBtn;
 let deleteBtn;
 let deletedTasks = 0;
 let isHidden = false;
 let isEditing = false;
-console.log(isEditing);
 
 // add event listener to button
 addBtn.addEventListener('click', (e) => {
@@ -50,7 +48,7 @@ addBtn.addEventListener('click', (e) => {
     controls.classList.add('controls');
 
     // create edit button with class edit-btn
-    editBtn = document.createElement('button');
+    const editBtn = document.createElement('button');
     editBtn.innerHTML = String.fromCodePoint(0x1F58B);
     editBtn.ariaLabel = "Edit";
     // assign delete button with class delete-btn

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ let deleteBtn;
 let deletedTasks = 0;
 let isHidden = false;
 let isEditing = false;
+console.log(isEditing);
 
 // add event listener to button
 addBtn.addEventListener('click', (e) => {
@@ -67,30 +68,26 @@ addBtn.addEventListener('click', (e) => {
     userInput.value = "";
 
     
-
     // event listener for edit button
     editBtn.addEventListener('click', () => {
-        // if we are in editing mode, clicking the button will save the changes
-        if (isEditing) {
-            // make new input value readonly
-            taskNew.setAttribute('readonly', 'readonly');
-            // reset button to edit emoji
-            editBtn.innerHTML = editBtn.innerHTML = String.fromCodePoint(0x1F58B)
-            // set isEditing to False 
-            isEditing = false;
-            console.log(isEditing);
-            console.dir(editBtn);
-        } else {
-            // this code block will run first because isEditing is initially set to false
+        // enter edit node
+        if (!isEditing) {
+            isEditing = true;
             // change button to save emoji
             editBtn.innerHTML = String.fromCodePoint(0x1F4CC);
             // enable input editing
             taskNew.removeAttribute('readonly');
             // focus on input in edit mode
             taskNew.focus();
-            // set isEditing to true
-            isEditing = true;
-            console.log(isEditing);
+            console.log('edit mode');
+        } else {
+            // save task
+            isEditing = false;
+            // make new input value readonly
+            taskNew.setAttribute('readonly', 'readonly');
+            // reset button to edit emoji
+            editBtn.innerHTML = editBtn.innerHTML = String.fromCodePoint(0x1F58B)
+            console.log('saved');
         }
     })
 

--- a/index.js
+++ b/index.js
@@ -8,16 +8,16 @@ let editBtn;
 let deleteBtn;
 let deletedTasks = 0;
 let isHidden = false;
+let isEditing = false;
 
 // add event listener to button
 addBtn.addEventListener('click', (e) => {
     //e.preventDefault();
     // get value of task from input
-
-    const taskValue = document.querySelector('input#task').value;
-    if(taskValue !== "") {
+    let userInput = document.querySelector('input#task');
+    // if user has entered a value, create a new task
+    if(userInput.value !== "") {
         e.preventDefault();
-    
     // create a div with a class of task-card
     const taskCard = document.createElement('div');
     taskCard.classList.add('task-card');
@@ -25,7 +25,7 @@ addBtn.addEventListener('click', (e) => {
     // create an input with class task-new
     const taskNew = document.createElement('input');
     taskNew.classList.add('task-new');
-    taskNew.value = taskValue;
+    taskNew.value = userInput.value;
     taskNew.setAttribute('readonly', 'readonly');
     
     // set checkboxes to appear once task has been added 
@@ -63,21 +63,34 @@ addBtn.addEventListener('click', (e) => {
     // append controls to task card
     taskCard.append(taskNew, controls);
     taskList.append(taskCard);
+    // clear the user input field
+    userInput.value = "";
+
+    
 
     // event listener for edit button
     editBtn.addEventListener('click', () => {
-        console.log(editBtn)
-        if (editBtn.textContent === 'Save') {
+        // if we are in editing mode, clicking the button will save the changes
+        if (isEditing) {
             // make new input value readonly
             taskNew.setAttribute('readonly', 'readonly');
-            editBtn.textContent = 'Edit';
+            // reset button to edit emoji
+            editBtn.innerHTML = editBtn.innerHTML = String.fromCodePoint(0x1F58B)
+            // set isEditing to False 
+            isEditing = false;
+            console.log(isEditing);
+            console.dir(editBtn);
         } else {
-            // change button text content
+            // this code block will run first because isEditing is initially set to false
+            // change button to save emoji
             editBtn.innerHTML = String.fromCodePoint(0x1F4CC);
             // enable input editing
             taskNew.removeAttribute('readonly');
             // focus on input in edit mode
             taskNew.focus();
+            // set isEditing to true
+            isEditing = true;
+            console.log(isEditing);
         }
     })
 
@@ -86,9 +99,10 @@ addBtn.addEventListener('click', (e) => {
     // hide task card
     deleteBtn.addEventListener('click', () => {
         deletedTasks++;
+        // taskCard.remove();
         taskCard.style.display = "none";
         })
-    }
+    }  
 })
 
 filterBtn.addEventListener('click', () => {

--- a/index.test.js
+++ b/index.test.js
@@ -62,6 +62,7 @@ test("Clicking the edit button enables editing", () => {
     // add new task
     addBtn.click();
     // click edit button
+    const editBtn = document.querySelector('[aria-label="Edit"]');
     editBtn.click();
     const input = document.querySelector('input.task-new');
     // check the readonly attribute has been removed

--- a/index.test.js
+++ b/index.test.js
@@ -66,6 +66,8 @@ test("Clicking the edit button enables editing", () => {
     const input = document.querySelector('input.task-new');
     // check the readonly attribute has been removed
     equal(input.getAttribute('readonly'), null, 'edit button removes readonly property');
+    // click edit button again to reset
+    editBtn.click();
     // remove test task card
     const taskCard = document.querySelector('.task-card');
     taskCard.remove();

--- a/index.test.js
+++ b/index.test.js
@@ -1,19 +1,25 @@
-
+// grab the input to assign and remove value in the tests
+let taskNew = document.querySelector('input#task');
 // Test for adding a new task to the to-do list
 
 test("Submitting a new task adds it to the list", () => {
     const before = taskList.childElementCount;
+    // give the input a value otherwise new task will not be created
+    taskNew.value = "New task";
     addBtn.click();
     const after = taskList.childElementCount;
     equal(after, before + 1)
     const taskCard = document.querySelector(".task-card")
-    taskCard.remove(); 
+    taskCard.remove();
+    // reset value to empty string
+    taskNew.value = ""; 
     })
 
 
 // Test for ticking completed items off the to-do list
 
 test("Checking an entry marks it as complete", () => {
+    taskNew.value = "New task";
     // Click add button
         addBtn.click(); 
     // grab checkbox from local scope
@@ -27,12 +33,15 @@ test("Checking an entry marks it as complete", () => {
     // equal function checks that the completed task is true
         equal(taskCardDone, true)
         taskCard.remove();
+        // reset value to empty string
+        taskNew.value = ""; 
     });
 
 // test for deleting an item from the to-do list
 test("Deleting an item removes it from the list", () => {
     // grab current number of deleted tasks (global variable in index.js)
     const currDeletedTasks = deletedTasks;
+    taskNew.value = "New task";
     // click add button to create task card with delete button inside
     addBtn.click();
     // click delete button
@@ -44,10 +53,12 @@ test("Deleting an item removes it from the list", () => {
     // remove test task card that was created in the test
     const taskCard = document.querySelector('.task-card');
     taskCard.remove();
+    taskNew.value = "";
 });
 
 // test for edit button
 test("Clicking the edit button enables editing", () => {
+    taskNew.value = "New task";
     // add new task
     addBtn.click();
     // click edit button
@@ -58,10 +69,12 @@ test("Clicking the edit button enables editing", () => {
     // remove test task card
     const taskCard = document.querySelector('.task-card');
     taskCard.remove();
+    taskNew.value = "";
 })
 
 // test for toggling a button to hide completed items
 test("Toggling the filter hides completed tasks from the list", () => {
+    taskNew.value = "New task";
     // add new task
     addBtn.click();
     // grab task card
@@ -74,5 +87,6 @@ test("Toggling the filter hides completed tasks from the list", () => {
     // check task card contain a classlist of 'completed-task' and a hidden attribute of true
     equal((taskCard.classList.contains('completed-task') && taskCard.style.display === "none"), true,'completed tasks are hidden')
     taskCard.remove();
+    taskNew.value = "";
     filterBtn.textContent = "Hide completed tasks";
 });


### PR DESCRIPTION
Hi Milly, 

I fixed the logic in the `editBtn` event listener to make the inputs editable and save-able 😄 .
It was broken because we replaced the `textContent` with emojis, and the logic was based on checking whether the `textContent` was set to 'Edit' or 'Save'. So instead of relying on text content, I created an `isDeleting` variable initially set to false to control the code execution. 

Then, I realised that when we click the `editBtn` once in the test, it changes the value of `isDeleting` (inside the event listener) so we need to click it again in the test to restore `isDeleting` back to false. 

Hope that makes sense - let me know if not! 